### PR TITLE
Update code so it works with newer esphome version

### DIFF
--- a/p1meterkit.yaml
+++ b/p1meterkit.yaml
@@ -8,11 +8,12 @@ substitutions:
 esphome:
   name: ${device_name}
   friendly_name: ${friendly_name}
-  board: d1_mini
-  platform: ESP8266
   project:
     name: "smarthomeshop.p1meterkit"
     version: ${p1meterkit_software_version}
+
+esp8266:
+ board: d1_mini
 
 # Enable logging
 logger:


### PR DESCRIPTION
esphome 2025.2 removes the platform block

This code compiles and runs successfully on my own P1MeterKit.
![image](https://github.com/user-attachments/assets/285116a2-e6e5-419f-bdda-63ee3133d198)